### PR TITLE
Remove unsupported ixgvevf parameter

### DIFF
--- a/ixgbevf.conf
+++ b/ixgbevf.conf
@@ -1,1 +1,3 @@
-options ixgbevf InterruptThrottleRate=1
+# No longer supported upstream or recommended by AWS
+# https://github.com/scalefactory/readyscale/issues/4061
+#options ixgbevf InterruptThrottleRate=1


### PR DESCRIPTION
The `ixgvevf` module in the mainline kernel no longer supports the `InterruptThrottleRate` and AWS no longer recommend the use of the parameter. This PR removes this parameter, leaving the module configuration file in-place with a link to the issue in RS.